### PR TITLE
[release/7.0.2xx] fixed dotnet/templating#5600 "No templates found" when required parameter is missing

### DIFF
--- a/src/Assets/TestPackages/dotnet-new/test_templates/TemplateResolution/MissedRequiredParameter/BasicTemplate1/.template.config/template.json
+++ b/src/Assets/TestPackages/dotnet-new/test_templates/TemplateResolution/MissedRequiredParameter/BasicTemplate1/.template.config/template.json
@@ -1,0 +1,23 @@
+{
+  "author": "Test Asset",
+  "classifications": [ "Test Asset" ],
+  "name": "Basic Template",
+  "generatorVersions": "[1.0.0.0-*)",
+  "groupIdentity": "TestAssets.MissedRequiredParameter",
+  "precedence": "100",
+  "identity": "TestAssets.MissedRequiredParameter.BasicTemplate1",
+  "shortName": "basic",
+  "sourceName": "bar",
+  "symbols": {
+    "param": {
+      "type": "parameter",
+      "datatype": "string",
+      "description": "parameter description",
+      "isRequired": true
+    }
+  },
+  "tags": {
+    "language": "C#",
+    "type": "item"
+  }
+}

--- a/src/Assets/TestPackages/dotnet-new/test_templates/TemplateResolution/MissedRequiredParameter/BasicTemplate2/.template.config/template.json
+++ b/src/Assets/TestPackages/dotnet-new/test_templates/TemplateResolution/MissedRequiredParameter/BasicTemplate2/.template.config/template.json
@@ -1,0 +1,28 @@
+{
+  "author": "Test Asset",
+  "classifications": [ "Test Asset" ],
+  "name": "Basic Template with condition",
+  "generatorVersions": "[1.0.0.0-*)",
+  "groupIdentity": "TestAssets.MissedRequiredParameter",
+  "precedence": "100",
+  "identity": "TestAssets.MissedRequiredParameter.BasicTemplate1",
+  "shortName": "basic2",
+  "sourceName": "bar",
+  "symbols": {
+    "param": {
+      "type": "parameter",
+      "datatype": "string",
+      "description": "parameter description",
+      "isRequired": "a_enabled",
+      "defaultValue": "def"
+    },
+    "a_enabled": {
+      "type": "parameter",
+      "datatype": "bool"
+    }
+  },
+  "tags": {
+    "language": "C#",
+    "type": "item"
+  }
+}

--- a/src/Assets/TestPackages/dotnet-new/test_templates/TemplateWithConditionalParameters/.template.config/template.json
+++ b/src/Assets/TestPackages/dotnet-new/test_templates/TemplateWithConditionalParameters/.template.config/template.json
@@ -11,15 +11,16 @@
     "paramA": {
       "type": "parameter",
       "datatype": "string",
-      "isEnabled": "A_enabled",
+      "description": "parameter A description",
+      "isEnabled": "A_enabled == true",
       "isRequired": true,
       "replaces": "placeholderA"
     },
     "paramB": {
       "type": "parameter",
       "datatype": "string",
-      "isEnabled": "B_enabled",
-      "isRequired": true,
+      "isEnabled": "B_enabled == true",
+      "description": "parameter B description",
       "replaces": "placeholderB"
     },
     "A_enabled": {

--- a/src/Assets/TestPackages/dotnet-new/test_templates/TemplateWithConditionalParameters/Test.cs
+++ b/src/Assets/TestPackages/dotnet-new/test_templates/TemplateWithConditionalParameters/Test.cs
@@ -2,10 +2,10 @@
 // value of paramA: placeholderA
 // value of paramB: placeholderB
 
-//#if( paramA )
-	// A is enabled
+//#if( A_enabled )
+// A is enabled
 //#endif
 
-//#if( paramB )
-	// B is enabled
+//#if( B_enabled )
+// B is enabled
 //#endif

--- a/src/Assets/TestPackages/dotnet-new/test_templates/TemplateWithRequiredParameters/.template.config/template.json
+++ b/src/Assets/TestPackages/dotnet-new/test_templates/TemplateWithRequiredParameters/.template.config/template.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json.schemastore.org/template.json",
+  "author": "Test Asset",
+  "classifications": [ "Test Asset" ],
+  "name": "TemplateWithRequiredParameters",
+  "generatorVersions": "[1.0.0.0-*)",
+  "groupIdentity": "TestAssets.TemplateWithRequiredParameters",
+  "precedence": "100",
+  "identity": "TestAssets.TemplateWithRequiredParameters",
+  "shortName": "TestAssets.TemplateWithRequiredParameters",
+  "symbols": {
+    "paramA": {
+      "type": "parameter",
+      "datatype": "string",
+      "description": "parameter A description",
+      "isRequired": true,
+      "replaces": "placeholderA"
+    },
+    "paramB": {
+      "type": "parameter",
+      "datatype": "string",
+      "description": "parameter B description",
+      "isRequired": true,
+      "replaces": "placeholderB",
+      "defaultValue": "def" //ignored
+    },
+    "paramC": {
+      "type": "parameter",
+      "datatype": "string",
+      "description": "parameter C description",
+      "isRequired": "enableC == true",
+      "replaces": "placeholderC",
+      "defaultValue": "def"
+    },
+    "enableC": {
+      "type": "parameter",
+      "datatype": "bool"
+    }
+  }
+}

--- a/src/Assets/TestPackages/dotnet-new/test_templates/TemplateWithRequiredParameters/Test.cs
+++ b/src/Assets/TestPackages/dotnet-new/test_templates/TemplateWithRequiredParameters/Test.cs
@@ -1,0 +1,4 @@
+
+// value of paramA: placeholderA
+// value of paramB: placeholderB
+// value of paramC: placeholderC

--- a/src/Cli/Microsoft.TemplateEngine.Cli/CliTemplateParameter.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/CliTemplateParameter.cs
@@ -142,11 +142,16 @@ namespace Microsoft.TemplateEngine.Cli
         {
             Option option = GetBaseOption(aliases);
             option.IsHidden = IsHidden;
-            option.IsRequired = IsRequired;
-            if (!string.IsNullOrWhiteSpace(DefaultValue)
-                || (Type == ParameterType.String || Type == ParameterType.Choice) && DefaultValue != null)
+
+            //if parameter is required, the default value is ignored.
+            //the user should always specify the parameter, so the default value is not even shown.
+            if (!IsRequired)
             {
-                option.SetDefaultValue(DefaultValue);
+                if (!string.IsNullOrWhiteSpace(DefaultValue)
+                    || (Type == ParameterType.String || Type == ParameterType.Choice) && DefaultValue != null)
+                {
+                    option.SetDefaultValue(DefaultValue);
+                }
             }
             option.Description = GetOptionDescription();
             return option;
@@ -326,6 +331,7 @@ namespace Microsoft.TemplateEngine.Cli
                 case PrecedenceDefinition.Disabled:
                     return HelpStrings.Text_Disabled;
                 case PrecedenceDefinition.Required:
+                    return (HelpStrings.Text_Required);
                 case PrecedenceDefinition.Optional:
                 case PrecedenceDefinition.Implicit:
                     return null;

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/HelpStrings.Designer.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/HelpStrings.Designer.cs
@@ -214,6 +214,15 @@ namespace Microsoft.TemplateEngine.Cli.Commands {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Required: *true*.
+        /// </summary>
+        internal static string Text_Required {
+            get {
+                return ResourceManager.GetString("Text_Required", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Required if: {0}.
         /// </summary>
         internal static string Text_RequiredCondition {

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/HelpStrings.resx
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/HelpStrings.resx
@@ -179,6 +179,10 @@
   <data name="Text_NoTemplateOptions" xml:space="preserve">
     <value>(No options)</value>
   </data>
+  <data name="Text_Required" xml:space="preserve">
+    <value>Required: *true*</value>
+    <comment>Indication that parameter is always required, do not translate "true".</comment>
+  </data>
   <data name="Text_RequiredCondition" xml:space="preserve">
     <value>Required if: {0}</value>
     <comment>{0} is the condition expression</comment>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/HelpStrings.cs.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/HelpStrings.cs.xlf
@@ -87,6 +87,11 @@
         <target state="translated">(Žádné možnosti)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Text_Required">
+        <source>Required: *true*</source>
+        <target state="new">Required: *true*</target>
+        <note>Indication that parameter is always required, do not translate "true".</note>
+      </trans-unit>
       <trans-unit id="Text_RequiredCondition">
         <source>Required if: {0}</source>
         <target state="translated">Povinné, pokud: {0}</target>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/HelpStrings.de.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/HelpStrings.de.xlf
@@ -87,6 +87,11 @@
         <target state="translated">(Keine Optionen)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Text_Required">
+        <source>Required: *true*</source>
+        <target state="new">Required: *true*</target>
+        <note>Indication that parameter is always required, do not translate "true".</note>
+      </trans-unit>
       <trans-unit id="Text_RequiredCondition">
         <source>Required if: {0}</source>
         <target state="translated">Erforderlich wenn: {0}</target>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/HelpStrings.es.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/HelpStrings.es.xlf
@@ -87,6 +87,11 @@
         <target state="translated">(No hay opciones)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Text_Required">
+        <source>Required: *true*</source>
+        <target state="new">Required: *true*</target>
+        <note>Indication that parameter is always required, do not translate "true".</note>
+      </trans-unit>
       <trans-unit id="Text_RequiredCondition">
         <source>Required if: {0}</source>
         <target state="translated">Requerido si: {0}</target>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/HelpStrings.fr.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/HelpStrings.fr.xlf
@@ -87,6 +87,11 @@
         <target state="translated">(Aucune option)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Text_Required">
+        <source>Required: *true*</source>
+        <target state="new">Required: *true*</target>
+        <note>Indication that parameter is always required, do not translate "true".</note>
+      </trans-unit>
       <trans-unit id="Text_RequiredCondition">
         <source>Required if: {0}</source>
         <target state="translated">Obligatoire si : {0}</target>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/HelpStrings.it.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/HelpStrings.it.xlf
@@ -87,6 +87,11 @@
         <target state="translated">Nessuna opzione</target>
         <note />
       </trans-unit>
+      <trans-unit id="Text_Required">
+        <source>Required: *true*</source>
+        <target state="new">Required: *true*</target>
+        <note>Indication that parameter is always required, do not translate "true".</note>
+      </trans-unit>
       <trans-unit id="Text_RequiredCondition">
         <source>Required if: {0}</source>
         <target state="translated">if obbligatorio: {0}</target>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/HelpStrings.ja.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/HelpStrings.ja.xlf
@@ -87,6 +87,11 @@
         <target state="translated">(オプションなし)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Text_Required">
+        <source>Required: *true*</source>
+        <target state="new">Required: *true*</target>
+        <note>Indication that parameter is always required, do not translate "true".</note>
+      </trans-unit>
       <trans-unit id="Text_RequiredCondition">
         <source>Required if: {0}</source>
         <target state="translated">必須の場合: {0}</target>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/HelpStrings.ko.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/HelpStrings.ko.xlf
@@ -87,6 +87,11 @@
         <target state="translated">(옵션 없음)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Text_Required">
+        <source>Required: *true*</source>
+        <target state="new">Required: *true*</target>
+        <note>Indication that parameter is always required, do not translate "true".</note>
+      </trans-unit>
       <trans-unit id="Text_RequiredCondition">
         <source>Required if: {0}</source>
         <target state="translated">다음 경우에 필요: {0}</target>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/HelpStrings.pl.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/HelpStrings.pl.xlf
@@ -87,6 +87,11 @@
         <target state="translated">(Brak opcji)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Text_Required">
+        <source>Required: *true*</source>
+        <target state="new">Required: *true*</target>
+        <note>Indication that parameter is always required, do not translate "true".</note>
+      </trans-unit>
       <trans-unit id="Text_RequiredCondition">
         <source>Required if: {0}</source>
         <target state="translated">Wymagane, jeśli: {0}</target>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/HelpStrings.pt-BR.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/HelpStrings.pt-BR.xlf
@@ -87,6 +87,11 @@
         <target state="translated">(Nenhuma opção)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Text_Required">
+        <source>Required: *true*</source>
+        <target state="new">Required: *true*</target>
+        <note>Indication that parameter is always required, do not translate "true".</note>
+      </trans-unit>
       <trans-unit id="Text_RequiredCondition">
         <source>Required if: {0}</source>
         <target state="translated">Obrigatório se: {0}</target>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/HelpStrings.ru.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/HelpStrings.ru.xlf
@@ -87,6 +87,11 @@
         <target state="translated">(Нет параметров)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Text_Required">
+        <source>Required: *true*</source>
+        <target state="new">Required: *true*</target>
+        <note>Indication that parameter is always required, do not translate "true".</note>
+      </trans-unit>
       <trans-unit id="Text_RequiredCondition">
         <source>Required if: {0}</source>
         <target state="translated">Требуется, если: {0}</target>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/HelpStrings.tr.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/HelpStrings.tr.xlf
@@ -87,6 +87,11 @@
         <target state="translated">(Seçenek yok)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Text_Required">
+        <source>Required: *true*</source>
+        <target state="new">Required: *true*</target>
+        <note>Indication that parameter is always required, do not translate "true".</note>
+      </trans-unit>
       <trans-unit id="Text_RequiredCondition">
         <source>Required if: {0}</source>
         <target state="translated">{0} ise gerekli</target>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/HelpStrings.zh-Hans.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/HelpStrings.zh-Hans.xlf
@@ -87,6 +87,11 @@
         <target state="translated">(无选项)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Text_Required">
+        <source>Required: *true*</source>
+        <target state="new">Required: *true*</target>
+        <note>Indication that parameter is always required, do not translate "true".</note>
+      </trans-unit>
       <trans-unit id="Text_RequiredCondition">
         <source>Required if: {0}</source>
         <target state="translated">在此条件下必需: {0}</target>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/HelpStrings.zh-Hant.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/HelpStrings.zh-Hant.xlf
@@ -87,6 +87,11 @@
         <target state="translated">(沒有選項)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Text_Required">
+        <source>Required: *true*</source>
+        <target state="new">Required: *true*</target>
+        <note>Indication that parameter is always required, do not translate "true".</note>
+      </trans-unit>
       <trans-unit id="Text_RequiredCondition">
         <source>Required if: {0}</source>
         <target state="translated">必要時間: {0}</target>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
@@ -983,7 +983,7 @@ namespace Microsoft.TemplateEngine.Cli {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Mandatory option &apos;{0}&apos; is missing for the template &apos;{1}&apos;..
+        ///   Looks up a localized string similar to Missing mandatory option(s) for the template &apos;{1}&apos;: {0}..
         /// </summary>
         internal static string MissingRequiredParameter {
             get {
@@ -1024,6 +1024,15 @@ namespace Microsoft.TemplateEngine.Cli {
         internal static string NoTemplatesFound {
             get {
                 return ResourceManager.GetString("NoTemplatesFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The operation was cancelled..
+        /// </summary>
+        internal static string OperationCancelled {
+            get {
+                return ResourceManager.GetString("OperationCancelled", resourceCulture);
             }
         }
         
@@ -1906,6 +1915,15 @@ namespace Microsoft.TemplateEngine.Cli {
         internal static string UnableToSetPermissions {
             get {
                 return ResourceManager.GetString("UnableToSetPermissions", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Template generation ended with unexpected result: &apos;{0}&apos;. Details: {1}.
+        /// </summary>
+        internal static string UnexpectedResult {
+            get {
+                return ResourceManager.GetString("UnexpectedResult", resourceCulture);
             }
         }
         

--- a/src/Cli/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
@@ -167,7 +167,8 @@
     <value>Language</value>
   </data>
   <data name="MissingRequiredParameter" xml:space="preserve">
-    <value>Mandatory option '{0}' is missing for the template '{1}'.</value>
+    <value>Missing mandatory option(s) for the template '{1}': {0}.</value>
+    <comment>{0} - comma-separated list of missing options, each option is quoted.</comment>
   </data>
   <data name="MountPointFactories" xml:space="preserve">
     <value>Mount Point Factories</value>
@@ -806,5 +807,11 @@ The header is followed by the list of parameters and their errors (might be seve
   </data>
   <data name="Generic_CommandHints_List" xml:space="preserve">
     <value>To list installed templates, run:</value>
+  </data>
+  <data name="OperationCancelled" xml:space="preserve">
+    <value>The operation was cancelled.</value>
+  </data>
+  <data name="UnexpectedResult" xml:space="preserve">
+    <value>Template generation ended with unexpected result: '{0}'. Details: {1}</value>
   </data>
 </root>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/TemplateInvoker.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/TemplateInvoker.cs
@@ -207,17 +207,19 @@ namespace Microsoft.TemplateEngine.Cli
 
                     return HandlePostActions(instantiateResult, templateArgs);
                 case CreationResultStatus.CreateFailed:
+                case CreationResultStatus.TemplateIssueDetected:
+                case CreationResultStatus.CondtionsEvaluationMismatch:
                     Reporter.Error.WriteLine(string.Format(LocalizableStrings.CreateFailed, resultTemplateName, instantiateResult.ErrorMessage).Bold().Red());
                     return NewCommandStatus.CreateFailed;
-                //this is unlikely case as these errors are caught on parse level now
                 //TODO: discuss if we need better handling here, then enhance core to return canonical names as array and not parse them from error message
+                //https://github.com/dotnet/templating/issues/4225
                 case CreationResultStatus.MissingMandatoryParam:
                     if (!string.IsNullOrWhiteSpace(instantiateResult.ErrorMessage))
                     {
-                        IReadOnlyList<string> missingParamNamesCanonical = instantiateResult.ErrorMessage.Split(new[] { ',' })
+                        IReadOnlyList<string> missingParamNamesCanonical = instantiateResult.ErrorMessage.Split(new[] { ',' }, StringSplitOptions.TrimEntries)
                             .Select(x => templateArgs.TryGetAliasForCanonicalName(x, out string? alias) ? alias! : x)
                             .ToList();
-                        string fixedMessage = string.Join(", ", missingParamNamesCanonical);
+                        string fixedMessage = string.Join(", ", missingParamNamesCanonical.Select(n => $"'{n}'"));
                         Reporter.Error.WriteLine(string.Format(LocalizableStrings.MissingRequiredParameter, fixedMessage, resultTemplateName).Bold().Red());
                     }
                     return NewCommandStatus.MissingRequiredOption;
@@ -279,7 +281,11 @@ namespace Microsoft.TemplateEngine.Cli
                         );
                     Reporter.Error.WriteCommand(Example.FromExistingTokens(templateArgs.ParseResult).WithOption(SharedOptions.ForceOption));
                     return NewCommandStatus.CannotCreateOutputFile;
+                case CreationResultStatus.Cancelled:
+                    Reporter.Error.WriteLine(LocalizableStrings.OperationCancelled.Bold().Red());
+                    return NewCommandStatus.Cancelled;
                 default:
+                    Reporter.Error.WriteLine(string.Format(LocalizableStrings.UnexpectedResult, Enum.GetName(typeof(CreationResultStatus), instantiateResult.Status), instantiateResult.ErrorMessage).Bold().Red());
                     return NewCommandStatus.Unexpected;
             }
         }

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.cs.xlf
@@ -524,9 +524,9 @@ The header is followed by the list of parameters and their errors (might be seve
         <note>{0} - command syntax, example: dotnet new [PARTIAL_NAME] --list [FILTER_OPTIONS].</note>
       </trans-unit>
       <trans-unit id="MissingRequiredParameter">
-        <source>Mandatory option '{0}' is missing for the template '{1}'.</source>
-        <target state="translated">U šablony {1} chybí povinná možnost {0}.</target>
-        <note />
+        <source>Missing mandatory option(s) for the template '{1}': {0}.</source>
+        <target state="needs-review-translation">U šablony {1} chybí povinná možnost {0}.</target>
+        <note>{0} - comma-separated list of missing options, each option is quoted.</note>
       </trans-unit>
       <trans-unit id="MountPointFactories">
         <source>Mount Point Factories</source>
@@ -546,6 +546,11 @@ The header is followed by the list of parameters and their errors (might be seve
       <trans-unit id="NoTemplatesFound">
         <source>No templates installed.</source>
         <target state="translated">Nejsou nainstalované žádné šablony.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OperationCancelled">
+        <source>The operation was cancelled.</source>
+        <target state="new">The operation was cancelled.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionalWorkloadsSyncFailed">
@@ -1055,6 +1060,11 @@ The header is followed by the list of parameters and their errors (might be seve
       <trans-unit id="UnableToSetPermissions">
         <source>Unable to apply permissions {0} to "{1}".</source>
         <target state="translated">Nedá se zavést oprávnění {0} do {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedResult">
+        <source>Template generation ended with unexpected result: '{0}'. Details: {1}</source>
+        <target state="new">Template generation ended with unexpected result: '{0}'. Details: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownChangeKind">

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.de.xlf
@@ -524,9 +524,9 @@ The header is followed by the list of parameters and their errors (might be seve
         <note>{0} - command syntax, example: dotnet new [PARTIAL_NAME] --list [FILTER_OPTIONS].</note>
       </trans-unit>
       <trans-unit id="MissingRequiredParameter">
-        <source>Mandatory option '{0}' is missing for the template '{1}'.</source>
-        <target state="translated">Die obligatorische Option „{0}“ fehlt für die Vorlage „{1}“.</target>
-        <note />
+        <source>Missing mandatory option(s) for the template '{1}': {0}.</source>
+        <target state="needs-review-translation">Die obligatorische Option „{0}“ fehlt für die Vorlage „{1}“.</target>
+        <note>{0} - comma-separated list of missing options, each option is quoted.</note>
       </trans-unit>
       <trans-unit id="MountPointFactories">
         <source>Mount Point Factories</source>
@@ -546,6 +546,11 @@ The header is followed by the list of parameters and their errors (might be seve
       <trans-unit id="NoTemplatesFound">
         <source>No templates installed.</source>
         <target state="translated">Keine Vorlagen installiert.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OperationCancelled">
+        <source>The operation was cancelled.</source>
+        <target state="new">The operation was cancelled.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionalWorkloadsSyncFailed">
@@ -1055,6 +1060,11 @@ The header is followed by the list of parameters and their errors (might be seve
       <trans-unit id="UnableToSetPermissions">
         <source>Unable to apply permissions {0} to "{1}".</source>
         <target state="translated">Die Berechtigungen {0} auf "{1}" können nicht angewendet werden.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedResult">
+        <source>Template generation ended with unexpected result: '{0}'. Details: {1}</source>
+        <target state="new">Template generation ended with unexpected result: '{0}'. Details: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownChangeKind">

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.es.xlf
@@ -524,9 +524,9 @@ The header is followed by the list of parameters and their errors (might be seve
         <note>{0} - command syntax, example: dotnet new [PARTIAL_NAME] --list [FILTER_OPTIONS].</note>
       </trans-unit>
       <trans-unit id="MissingRequiredParameter">
-        <source>Mandatory option '{0}' is missing for the template '{1}'.</source>
-        <target state="translated">Falta la opción obligatoria '{0}' para la plantilla '{1}'.</target>
-        <note />
+        <source>Missing mandatory option(s) for the template '{1}': {0}.</source>
+        <target state="needs-review-translation">Falta la opción obligatoria '{0}' para la plantilla '{1}'.</target>
+        <note>{0} - comma-separated list of missing options, each option is quoted.</note>
       </trans-unit>
       <trans-unit id="MountPointFactories">
         <source>Mount Point Factories</source>
@@ -546,6 +546,11 @@ The header is followed by the list of parameters and their errors (might be seve
       <trans-unit id="NoTemplatesFound">
         <source>No templates installed.</source>
         <target state="translated">No hay plantillas instaladas.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OperationCancelled">
+        <source>The operation was cancelled.</source>
+        <target state="new">The operation was cancelled.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionalWorkloadsSyncFailed">
@@ -1055,6 +1060,11 @@ The header is followed by the list of parameters and their errors (might be seve
       <trans-unit id="UnableToSetPermissions">
         <source>Unable to apply permissions {0} to "{1}".</source>
         <target state="translated">No se pueden aplicar los permisos {0} a "{1}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedResult">
+        <source>Template generation ended with unexpected result: '{0}'. Details: {1}</source>
+        <target state="new">Template generation ended with unexpected result: '{0}'. Details: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownChangeKind">

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.fr.xlf
@@ -524,9 +524,9 @@ The header is followed by the list of parameters and their errors (might be seve
         <note>{0} - command syntax, example: dotnet new [PARTIAL_NAME] --list [FILTER_OPTIONS].</note>
       </trans-unit>
       <trans-unit id="MissingRequiredParameter">
-        <source>Mandatory option '{0}' is missing for the template '{1}'.</source>
-        <target state="translated">L’option obligatoire '{0}' est manquante pour le modèle '{1}'.</target>
-        <note />
+        <source>Missing mandatory option(s) for the template '{1}': {0}.</source>
+        <target state="needs-review-translation">L’option obligatoire '{0}' est manquante pour le modèle '{1}'.</target>
+        <note>{0} - comma-separated list of missing options, each option is quoted.</note>
       </trans-unit>
       <trans-unit id="MountPointFactories">
         <source>Mount Point Factories</source>
@@ -546,6 +546,11 @@ The header is followed by the list of parameters and their errors (might be seve
       <trans-unit id="NoTemplatesFound">
         <source>No templates installed.</source>
         <target state="translated">Aucun modèle installé</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OperationCancelled">
+        <source>The operation was cancelled.</source>
+        <target state="new">The operation was cancelled.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionalWorkloadsSyncFailed">
@@ -1055,6 +1060,11 @@ The header is followed by the list of parameters and their errors (might be seve
       <trans-unit id="UnableToSetPermissions">
         <source>Unable to apply permissions {0} to "{1}".</source>
         <target state="translated">Impossible d’appliquer les autorisations {0} à « {1} ».</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedResult">
+        <source>Template generation ended with unexpected result: '{0}'. Details: {1}</source>
+        <target state="new">Template generation ended with unexpected result: '{0}'. Details: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownChangeKind">

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.it.xlf
@@ -524,9 +524,9 @@ The header is followed by the list of parameters and their errors (might be seve
         <note>{0} - command syntax, example: dotnet new [PARTIAL_NAME] --list [FILTER_OPTIONS].</note>
       </trans-unit>
       <trans-unit id="MissingRequiredParameter">
-        <source>Mandatory option '{0}' is missing for the template '{1}'.</source>
-        <target state="translated">Manca '{0}' l'opzione obbligatoria per il modello '{1}'.</target>
-        <note />
+        <source>Missing mandatory option(s) for the template '{1}': {0}.</source>
+        <target state="needs-review-translation">Manca '{0}' l'opzione obbligatoria per il modello '{1}'.</target>
+        <note>{0} - comma-separated list of missing options, each option is quoted.</note>
       </trans-unit>
       <trans-unit id="MountPointFactories">
         <source>Mount Point Factories</source>
@@ -546,6 +546,11 @@ The header is followed by the list of parameters and their errors (might be seve
       <trans-unit id="NoTemplatesFound">
         <source>No templates installed.</source>
         <target state="translated">Nessun modello installato.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OperationCancelled">
+        <source>The operation was cancelled.</source>
+        <target state="new">The operation was cancelled.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionalWorkloadsSyncFailed">
@@ -1055,6 +1060,11 @@ The header is followed by the list of parameters and their errors (might be seve
       <trans-unit id="UnableToSetPermissions">
         <source>Unable to apply permissions {0} to "{1}".</source>
         <target state="translated">Non è possibile applicare le autorizzazioni {0} a "{1}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedResult">
+        <source>Template generation ended with unexpected result: '{0}'. Details: {1}</source>
+        <target state="new">Template generation ended with unexpected result: '{0}'. Details: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownChangeKind">

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ja.xlf
@@ -524,9 +524,9 @@ The header is followed by the list of parameters and their errors (might be seve
         <note>{0} - command syntax, example: dotnet new [PARTIAL_NAME] --list [FILTER_OPTIONS].</note>
       </trans-unit>
       <trans-unit id="MissingRequiredParameter">
-        <source>Mandatory option '{0}' is missing for the template '{1}'.</source>
-        <target state="translated">テンプレート '{1}' の必須パラメーター '{0}' がありません。</target>
-        <note />
+        <source>Missing mandatory option(s) for the template '{1}': {0}.</source>
+        <target state="needs-review-translation">テンプレート '{1}' の必須パラメーター '{0}' がありません。</target>
+        <note>{0} - comma-separated list of missing options, each option is quoted.</note>
       </trans-unit>
       <trans-unit id="MountPointFactories">
         <source>Mount Point Factories</source>
@@ -546,6 +546,11 @@ The header is followed by the list of parameters and their errors (might be seve
       <trans-unit id="NoTemplatesFound">
         <source>No templates installed.</source>
         <target state="translated">テンプレートがインストールされていません。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OperationCancelled">
+        <source>The operation was cancelled.</source>
+        <target state="new">The operation was cancelled.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionalWorkloadsSyncFailed">
@@ -1055,6 +1060,11 @@ The header is followed by the list of parameters and their errors (might be seve
       <trans-unit id="UnableToSetPermissions">
         <source>Unable to apply permissions {0} to "{1}".</source>
         <target state="translated">アクセス許可 {0} を "{1}" に適用できません。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedResult">
+        <source>Template generation ended with unexpected result: '{0}'. Details: {1}</source>
+        <target state="new">Template generation ended with unexpected result: '{0}'. Details: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownChangeKind">

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ko.xlf
@@ -524,9 +524,9 @@ The header is followed by the list of parameters and their errors (might be seve
         <note>{0} - command syntax, example: dotnet new [PARTIAL_NAME] --list [FILTER_OPTIONS].</note>
       </trans-unit>
       <trans-unit id="MissingRequiredParameter">
-        <source>Mandatory option '{0}' is missing for the template '{1}'.</source>
-        <target state="translated">'{1}' 템플릿에 대한 '{0}' 필수 옵션이 없습니다.</target>
-        <note />
+        <source>Missing mandatory option(s) for the template '{1}': {0}.</source>
+        <target state="needs-review-translation">'{1}' 템플릿에 대한 '{0}' 필수 옵션이 없습니다.</target>
+        <note>{0} - comma-separated list of missing options, each option is quoted.</note>
       </trans-unit>
       <trans-unit id="MountPointFactories">
         <source>Mount Point Factories</source>
@@ -546,6 +546,11 @@ The header is followed by the list of parameters and their errors (might be seve
       <trans-unit id="NoTemplatesFound">
         <source>No templates installed.</source>
         <target state="translated">템플릿이 설치되어 있지 않습니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OperationCancelled">
+        <source>The operation was cancelled.</source>
+        <target state="new">The operation was cancelled.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionalWorkloadsSyncFailed">
@@ -1055,6 +1060,11 @@ The header is followed by the list of parameters and their errors (might be seve
       <trans-unit id="UnableToSetPermissions">
         <source>Unable to apply permissions {0} to "{1}".</source>
         <target state="translated">{0} 권한을 "{1}"에 적용할 수 없습니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedResult">
+        <source>Template generation ended with unexpected result: '{0}'. Details: {1}</source>
+        <target state="new">Template generation ended with unexpected result: '{0}'. Details: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownChangeKind">

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pl.xlf
@@ -524,9 +524,9 @@ The header is followed by the list of parameters and their errors (might be seve
         <note>{0} - command syntax, example: dotnet new [PARTIAL_NAME] --list [FILTER_OPTIONS].</note>
       </trans-unit>
       <trans-unit id="MissingRequiredParameter">
-        <source>Mandatory option '{0}' is missing for the template '{1}'.</source>
-        <target state="translated">W przypadku szablonu „{1}” brakuje opcji obowiązkowej „{0}”.</target>
-        <note />
+        <source>Missing mandatory option(s) for the template '{1}': {0}.</source>
+        <target state="needs-review-translation">W przypadku szablonu „{1}” brakuje opcji obowiązkowej „{0}”.</target>
+        <note>{0} - comma-separated list of missing options, each option is quoted.</note>
       </trans-unit>
       <trans-unit id="MountPointFactories">
         <source>Mount Point Factories</source>
@@ -546,6 +546,11 @@ The header is followed by the list of parameters and their errors (might be seve
       <trans-unit id="NoTemplatesFound">
         <source>No templates installed.</source>
         <target state="translated">Nie zainstalowano żadnych szablonów.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OperationCancelled">
+        <source>The operation was cancelled.</source>
+        <target state="new">The operation was cancelled.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionalWorkloadsSyncFailed">
@@ -1055,6 +1060,11 @@ The header is followed by the list of parameters and their errors (might be seve
       <trans-unit id="UnableToSetPermissions">
         <source>Unable to apply permissions {0} to "{1}".</source>
         <target state="translated">Nie można zastosować uprawnień {0} do „{1}”.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedResult">
+        <source>Template generation ended with unexpected result: '{0}'. Details: {1}</source>
+        <target state="new">Template generation ended with unexpected result: '{0}'. Details: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownChangeKind">

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pt-BR.xlf
@@ -524,9 +524,9 @@ The header is followed by the list of parameters and their errors (might be seve
         <note>{0} - command syntax, example: dotnet new [PARTIAL_NAME] --list [FILTER_OPTIONS].</note>
       </trans-unit>
       <trans-unit id="MissingRequiredParameter">
-        <source>Mandatory option '{0}' is missing for the template '{1}'.</source>
-        <target state="translated">A opção obrigatória '{0}' está faltando para o modelo '{1}'.</target>
-        <note />
+        <source>Missing mandatory option(s) for the template '{1}': {0}.</source>
+        <target state="needs-review-translation">A opção obrigatória '{0}' está faltando para o modelo '{1}'.</target>
+        <note>{0} - comma-separated list of missing options, each option is quoted.</note>
       </trans-unit>
       <trans-unit id="MountPointFactories">
         <source>Mount Point Factories</source>
@@ -546,6 +546,11 @@ The header is followed by the list of parameters and their errors (might be seve
       <trans-unit id="NoTemplatesFound">
         <source>No templates installed.</source>
         <target state="translated">Nenhum modelo instalado.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OperationCancelled">
+        <source>The operation was cancelled.</source>
+        <target state="new">The operation was cancelled.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionalWorkloadsSyncFailed">
@@ -1055,6 +1060,11 @@ The header is followed by the list of parameters and their errors (might be seve
       <trans-unit id="UnableToSetPermissions">
         <source>Unable to apply permissions {0} to "{1}".</source>
         <target state="translated">Não é possível aplicar as permissões {0} a "{1}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedResult">
+        <source>Template generation ended with unexpected result: '{0}'. Details: {1}</source>
+        <target state="new">Template generation ended with unexpected result: '{0}'. Details: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownChangeKind">

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ru.xlf
@@ -524,9 +524,9 @@ The header is followed by the list of parameters and their errors (might be seve
         <note>{0} - command syntax, example: dotnet new [PARTIAL_NAME] --list [FILTER_OPTIONS].</note>
       </trans-unit>
       <trans-unit id="MissingRequiredParameter">
-        <source>Mandatory option '{0}' is missing for the template '{1}'.</source>
-        <target state="translated">Отсутствует обязательный параметр "{0}" для шаблона "{1}".</target>
-        <note />
+        <source>Missing mandatory option(s) for the template '{1}': {0}.</source>
+        <target state="needs-review-translation">Отсутствует обязательный параметр "{0}" для шаблона "{1}".</target>
+        <note>{0} - comma-separated list of missing options, each option is quoted.</note>
       </trans-unit>
       <trans-unit id="MountPointFactories">
         <source>Mount Point Factories</source>
@@ -546,6 +546,11 @@ The header is followed by the list of parameters and their errors (might be seve
       <trans-unit id="NoTemplatesFound">
         <source>No templates installed.</source>
         <target state="translated">Шаблоны не установлены.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OperationCancelled">
+        <source>The operation was cancelled.</source>
+        <target state="new">The operation was cancelled.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionalWorkloadsSyncFailed">
@@ -1055,6 +1060,11 @@ The header is followed by the list of parameters and their errors (might be seve
       <trans-unit id="UnableToSetPermissions">
         <source>Unable to apply permissions {0} to "{1}".</source>
         <target state="translated">Не удалось применить разрешения {0} к "{1}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedResult">
+        <source>Template generation ended with unexpected result: '{0}'. Details: {1}</source>
+        <target state="new">Template generation ended with unexpected result: '{0}'. Details: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownChangeKind">

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.tr.xlf
@@ -524,9 +524,9 @@ The header is followed by the list of parameters and their errors (might be seve
         <note>{0} - command syntax, example: dotnet new [PARTIAL_NAME] --list [FILTER_OPTIONS].</note>
       </trans-unit>
       <trans-unit id="MissingRequiredParameter">
-        <source>Mandatory option '{0}' is missing for the template '{1}'.</source>
-        <target state="translated">'{1}' şablonunda zorunlu '{0}' seçeneği eksik.</target>
-        <note />
+        <source>Missing mandatory option(s) for the template '{1}': {0}.</source>
+        <target state="needs-review-translation">'{1}' şablonunda zorunlu '{0}' seçeneği eksik.</target>
+        <note>{0} - comma-separated list of missing options, each option is quoted.</note>
       </trans-unit>
       <trans-unit id="MountPointFactories">
         <source>Mount Point Factories</source>
@@ -546,6 +546,11 @@ The header is followed by the list of parameters and their errors (might be seve
       <trans-unit id="NoTemplatesFound">
         <source>No templates installed.</source>
         <target state="translated">Yüklü şablon yok.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OperationCancelled">
+        <source>The operation was cancelled.</source>
+        <target state="new">The operation was cancelled.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionalWorkloadsSyncFailed">
@@ -1055,6 +1060,11 @@ The header is followed by the list of parameters and their errors (might be seve
       <trans-unit id="UnableToSetPermissions">
         <source>Unable to apply permissions {0} to "{1}".</source>
         <target state="translated">{0} izinleri "{1}" öğesine uygulanamıyor.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedResult">
+        <source>Template generation ended with unexpected result: '{0}'. Details: {1}</source>
+        <target state="new">Template generation ended with unexpected result: '{0}'. Details: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownChangeKind">

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hans.xlf
@@ -524,9 +524,9 @@ The header is followed by the list of parameters and their errors (might be seve
         <note>{0} - command syntax, example: dotnet new [PARTIAL_NAME] --list [FILTER_OPTIONS].</note>
       </trans-unit>
       <trans-unit id="MissingRequiredParameter">
-        <source>Mandatory option '{0}' is missing for the template '{1}'.</source>
-        <target state="translated">模板“{1}”缺少必备选项“{0}”。</target>
-        <note />
+        <source>Missing mandatory option(s) for the template '{1}': {0}.</source>
+        <target state="needs-review-translation">模板“{1}”缺少必备选项“{0}”。</target>
+        <note>{0} - comma-separated list of missing options, each option is quoted.</note>
       </trans-unit>
       <trans-unit id="MountPointFactories">
         <source>Mount Point Factories</source>
@@ -546,6 +546,11 @@ The header is followed by the list of parameters and their errors (might be seve
       <trans-unit id="NoTemplatesFound">
         <source>No templates installed.</source>
         <target state="translated">未安装模板。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OperationCancelled">
+        <source>The operation was cancelled.</source>
+        <target state="new">The operation was cancelled.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionalWorkloadsSyncFailed">
@@ -1055,6 +1060,11 @@ The header is followed by the list of parameters and their errors (might be seve
       <trans-unit id="UnableToSetPermissions">
         <source>Unable to apply permissions {0} to "{1}".</source>
         <target state="translated">无法将权限 {0} 应用于“{1}”。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedResult">
+        <source>Template generation ended with unexpected result: '{0}'. Details: {1}</source>
+        <target state="new">Template generation ended with unexpected result: '{0}'. Details: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownChangeKind">

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hant.xlf
@@ -524,9 +524,9 @@ The header is followed by the list of parameters and their errors (might be seve
         <note>{0} - command syntax, example: dotnet new [PARTIAL_NAME] --list [FILTER_OPTIONS].</note>
       </trans-unit>
       <trans-unit id="MissingRequiredParameter">
-        <source>Mandatory option '{0}' is missing for the template '{1}'.</source>
-        <target state="translated">範本 '{1}'缺少強制選項 '{0}'。</target>
-        <note />
+        <source>Missing mandatory option(s) for the template '{1}': {0}.</source>
+        <target state="needs-review-translation">範本 '{1}'缺少強制選項 '{0}'。</target>
+        <note>{0} - comma-separated list of missing options, each option is quoted.</note>
       </trans-unit>
       <trans-unit id="MountPointFactories">
         <source>Mount Point Factories</source>
@@ -546,6 +546,11 @@ The header is followed by the list of parameters and their errors (might be seve
       <trans-unit id="NoTemplatesFound">
         <source>No templates installed.</source>
         <target state="translated">未安裝範本。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OperationCancelled">
+        <source>The operation was cancelled.</source>
+        <target state="new">The operation was cancelled.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionalWorkloadsSyncFailed">
@@ -1055,6 +1060,11 @@ The header is followed by the list of parameters and their errors (might be seve
       <trans-unit id="UnableToSetPermissions">
         <source>Unable to apply permissions {0} to "{1}".</source>
         <target state="translated">無法將權限 {0} 套用至「{1}」。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedResult">
+        <source>Template generation ended with unexpected result: '{0}'. Details: {1}</source>
+        <target state="new">Template generation ended with unexpected result: '{0}'. Details: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownChangeKind">

--- a/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/Approvals/HelpTests.CanShowTemplateOptions_RequiredParam.verified.txt
+++ b/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/Approvals/HelpTests.CanShowTemplateOptions_RequiredParam.verified.txt
@@ -1,0 +1,11 @@
+﻿Template options:
+  -c, --choice <choice>  my description
+                         Required: *true*
+                         Type: choice
+                           val1  
+                           val2  
+                           val3  
+                           val4  
+                           val5  
+                           val6
+

--- a/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/Approvals/HelpTests.CanShowTemplateOptions_SingleTemplate_Choice_Required.verified.txt
+++ b/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/Approvals/HelpTests.CanShowTemplateOptions_SingleTemplate_Choice_Required.verified.txt
@@ -1,7 +1,8 @@
 ﻿Template options:
-  -c, --choice <val1|val2> (REQUIRED)  my description
-                                       Type: choice
-                                         val1  
-                                         val2  
-                                       Default if option is provided without a value: def-val-no-arg
+  -c, --choice <val1|val2>  my description
+                            Required: *true*
+                            Type: choice
+                              val1  
+                              val2  
+                            Default if option is provided without a value: def-val-no-arg
 

--- a/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/HelpTests.cs
+++ b/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/HelpTests.cs
@@ -447,5 +447,29 @@ Author: Me
             InstantiateCommand.ShowTemplateSpecificOptions(new[] { templateCommand1, templateCommand2 }, helpContext);
             return Verifier.Verify(sw.ToString());
         }
+
+        [Fact]
+        public Task CanShowTemplateOptions_RequiredParam()
+        {
+            MockTemplateInfo template = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group")
+                .WithChoiceParameter("choice", new[] { "val1", "val2", "val3", "val4", "val5", "val6" }, description: "my description", isRequired: true);
+            TemplateGroup templateGroup = TemplateGroup.FromTemplateList(
+               CliTemplateInfo.FromTemplateInfo(new[] { template }, A.Fake<IHostSpecificDataLoader>()))
+               .Single();
+
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost();
+            IEngineEnvironmentSettings settings = new EngineEnvironmentSettings(host, virtualizeSettings: true);
+            TemplatePackageManager packageManager = A.Fake<TemplatePackageManager>();
+
+            NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
+
+            TemplateCommand templateCommand = new(myCommand, settings, packageManager, templateGroup, templateGroup.Templates.Single());
+
+            StringWriter sw = new();
+            HelpContext helpContext = new(new HelpBuilder(LocalizationResources.Instance, maxWidth: 50), myCommand, sw);
+
+            InstantiateCommand.ShowTemplateSpecificOptions(new[] { templateCommand }, helpContext);
+            return Verify(sw.ToString());
+        }
     }
 }

--- a/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/InstantiateTests.cs
+++ b/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/InstantiateTests.cs
@@ -437,27 +437,27 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
             new object?[][]
             {
                 //bool
-                new object?[] { "foo", "bool", "bool", true, null, null, "Option '--bool' is required." },
+                //new object?[] { "foo", "bool", "bool", true, null, null, "Option '--bool' is required." },
                 new object?[] { "foo -b text", "bool", "bool", true, null, null, "Unrecognized command or argument 'text'." },
                 new object?[] { "foo --bool 0", "bool", "bool", true, null, null, "Unrecognized command or argument '0'." },
                 //text
                 new object?[] { "foo --text", "text", "string", false, null, null, "Required argument missing for option: '--text'." },
-                new object?[] { "foo", "text", "string", true, null, null, "Option '--text' is required." },
+                //new object?[] { "foo", "text", "string", true, null, null, "Option '--text' is required." },
                 //int
                 new object?[] { "foo --int text", "int", "int", false, null, null, "Cannot parse argument 'text' for option '--int' as expected type 'Int64'." },
                 new object?[] { "foo --int", "int", "int", false, null, null, "Required argument missing for option: '--int'." },
-                new object?[] { "foo", "int", "int", true, null, null, "Option '--int' is required." },
+                //new object?[] { "foo", "int", "int", true, null, null, "Option '--int' is required." },
                 new object?[] { "foo --int", "int", "int", true, null, "not-int", "Cannot parse default if option without value 'not-int' for option '--int' as expected type 'Int64'." },
                 //float
                 new object?[] { "foo --float text", "float", "float", false, null, null, "Cannot parse argument 'text' for option '--float' as expected type 'Double'." },
                 new object?[] { "foo --float", "float", "float", false, null, null, "Required argument missing for option: '--float'." },
-                new object?[] { "foo", "float", "float", true, null, null, "Option '--float' is required." },
+                //new object?[] { "foo", "float", "float", true, null, null, "Option '--float' is required." },
                 new object?[] { "foo --float", "float", "float", true, null, "not-float", "Cannot parse default if option without value 'not-float' for option '--float' as expected type 'Double'." },
 
                 //hex
                 new object?[] { "foo --hex text", "hex", "hex", false, null, null, "Cannot parse argument 'text' for option '--hex' as expected type 'Int64'." },
                 new object?[] { "foo --hex", "hex", "hex", false, null, null, "Required argument missing for option: '--hex'." },
-                new object?[] { "foo", "hex", "hex", true, null, null, "Option '--hex' is required." },
+               // new object?[] { "foo", "hex", "hex", true, null, null, "Option '--hex' is required." },
                 new object?[] { "foo --hex", "hex", "hex", true, null, "not-hex", "Cannot parse default if option without value 'not-hex' for option '--hex' as expected type 'Int64'." },
 
             };
@@ -503,7 +503,8 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
                 new object?[] { "foo --framework netcoreapp3.1", "framework", "net5.0|net6.0", false, null, null, "Argument(s) 'netcoreapp3.1' are not recognized. Must be one of: 'net5.0', 'net6.0'." },
                 //https://github.com/dotnet/command-line-api/issues/1609
                 //new object?[] { "foo --framework", "framework", "net5.0|net6.0", false, null, null, "Required argument missing for option: '--framework'." },
-                new object?[] { "foo", "framework", "net5.0|net6.0", true, null, null, "Option '--framework' is required." },
+                //requireness is no longer set on parser level
+                //new object?[] { "foo", "framework", "net5.0|net6.0", true, null, null, "Option '--framework' is required." },
                 new object?[] { "foo --framework", "framework", "net5.0|net6.0", true, null, "netcoreapp2.1", $"Cannot parse default if option without value 'netcoreapp2.1' for option '--framework' as expected type 'choice': value 'netcoreapp2.1' is not allowed, allowed values are: 'net5.0','net6.0'. Did you mean one of the following?{Environment.NewLine}net5.0{Environment.NewLine}net6.0" }
             };
 
@@ -763,6 +764,28 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
             var templateArgs = new TemplateCommandArgs(templateCommand, myCommand, templateParseResult);
 
             Assert.True(expectedAction(templateArgs));
+        }
+
+        [Fact]
+        internal void CanParse_WithoutRequiredParameter()
+        {
+            MockTemplateInfo template = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group")
+            .WithChoiceParameter("param", new[] { "val1", "val2" }, isRequired: true);
+            TemplateGroup templateGroup = TemplateGroup.FromTemplateList(
+                CliTemplateInfo.FromTemplateInfo(new[] { template }, A.Fake<IHostSpecificDataLoader>()))
+                .Single();
+
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost();
+            IEngineEnvironmentSettings settings = new EngineEnvironmentSettings(host, virtualizeSettings: true);
+            TemplatePackageManager packageManager = A.Fake<TemplatePackageManager>();
+
+            RootCommand rootCommand = new();
+            NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
+            rootCommand.AddCommand(myCommand);
+            ParseResult parseResult = rootCommand.Parse("new foo");
+            InstantiateCommandArgs args = InstantiateCommandArgs.FromNewCommandArgs(new NewCommandArgs(myCommand, parseResult));
+            HashSet<TemplateCommand> templateCommands = InstantiateCommand.GetTemplateCommand(args, settings, A.Fake<TemplatePackageManager>(), templateGroup);
+            Assert.Single(templateCommands);
         }
     }
 }

--- a/src/Tests/dotnet-new.Tests/Approvals/DotnetNewHelpTests.CanShowHelpForTemplateWhenRequiredParamIsMissed.verified.txt
+++ b/src/Tests/dotnet-new.Tests/Approvals/DotnetNewHelpTests.CanShowHelpForTemplateWhenRequiredParamIsMissed.verified.txt
@@ -1,0 +1,20 @@
+﻿Basic Template (C#)
+Author: Test Asset
+
+Usage:
+  dotnet new basic [options] [template options]
+
+Options:
+  -n, --name <name>       The name for the output being created. If no name is specified, the name of the output directory is used.
+  -o, --output <output>   Location to place the generated output.
+  --dry-run               Displays a summary of what would happen if the given command line were run if it would result in a template creation.
+  --force                 Forces content to be generated even if it would change existing files.
+  --no-update-check       Disables checking for the template package updates when instantiating a template.
+  --project <project>     The project that should be used for context evaluation.
+  -lang, --language <C#>  Specifies the template language to instantiate.
+  --type <item>           Specifies the template type to instantiate.
+
+Template options:
+  -p, --param <param>  parameter description
+                       Required: *true*
+                       Type: string

--- a/src/Tests/dotnet-new.Tests/Approvals/DotnetNewHelpTests.CanShowHelpForTemplateWhenRequiredParamIsMissedAndConditionIntroduced.verified.txt
+++ b/src/Tests/dotnet-new.Tests/Approvals/DotnetNewHelpTests.CanShowHelpForTemplateWhenRequiredParamIsMissedAndConditionIntroduced.verified.txt
@@ -1,0 +1,22 @@
+﻿Basic Template with condition (C#)
+Author: Test Asset
+
+Usage:
+  dotnet new basic2 [options] [template options]
+
+Options:
+  -n, --name <name>       The name for the output being created. If no name is specified, the name of the output directory is used.
+  -o, --output <output>   Location to place the generated output.
+  --dry-run               Displays a summary of what would happen if the given command line were run if it would result in a template creation.
+  --force                 Forces content to be generated even if it would change existing files.
+  --no-update-check       Disables checking for the template package updates when instantiating a template.
+  --project <project>     The project that should be used for context evaluation.
+  -lang, --language <C#>  Specifies the template language to instantiate.
+  --type <item>           Specifies the template type to instantiate.
+
+Template options:
+  -p, --param <param>  parameter description
+                       Required if: a_enabled
+                       Type: string
+                       Default: def
+  -a_, --a_enabled     Type: bool

--- a/src/Tests/dotnet-new.Tests/Approvals/DotnetNewHelpTests.CanShowHelpForTemplate_ConditionalParams.verified.txt
+++ b/src/Tests/dotnet-new.Tests/Approvals/DotnetNewHelpTests.CanShowHelpForTemplate_ConditionalParams.verified.txt
@@ -1,0 +1,24 @@
+﻿TemplateWithConditionalParameters
+Author: Test Asset
+
+Usage:
+  dotnet new TestAssets.TemplateWithConditionalParameters [options] [template options]
+
+Options:
+  -n, --name <name>      The name for the output being created. If no name is specified, the name of the output directory is used.
+  -o, --output <output>  Location to place the generated output.
+  --dry-run              Displays a summary of what would happen if the given command line were run if it would result in a template creation.
+  --force                Forces content to be generated even if it would change existing files.
+  --no-update-check      Disables checking for the template package updates when instantiating a template.
+  --project <project>    The project that should be used for context evaluation.
+
+Template options:
+  -p, --paramA <paramA>   parameter A description
+                          Enabled if: A_enabled == true
+                          Type: string
+  -pa, --paramB <paramB>  parameter B description
+                          Enabled if: B_enabled == true
+                          Type: string
+                          Default: placeholderB
+  -A, --A_enabled         Type: bool
+  -B, --B_enabled         Type: bool

--- a/src/Tests/dotnet-new.Tests/Approvals/DotnetNewHelpTests.CanShowHelpForTemplate_RequiredParams.verified.txt
+++ b/src/Tests/dotnet-new.Tests/Approvals/DotnetNewHelpTests.CanShowHelpForTemplate_RequiredParams.verified.txt
@@ -1,0 +1,27 @@
+﻿TemplateWithRequiredParameters
+Author: Test Asset
+
+Usage:
+  dotnet new TestAssets.TemplateWithRequiredParameters [options] [template options]
+
+Options:
+  -n, --name <name>      The name for the output being created. If no name is specified, the name of the output directory is used.
+  -o, --output <output>  Location to place the generated output.
+  --dry-run              Displays a summary of what would happen if the given command line were run if it would result in a template creation.
+  --force                Forces content to be generated even if it would change existing files.
+  --no-update-check      Disables checking for the template package updates when instantiating a template.
+  --project <project>    The project that should be used for context evaluation.
+
+Template options:
+  -p, --paramA <paramA>    parameter A description
+                           Required: *true*
+                           Type: string
+  -pa, --paramB <paramB>   parameter B description
+                           Required: *true*
+                           Type: string
+                           Default: def
+  -p:p, --paramC <paramC>  parameter C description
+                           Required if: enableC == true
+                           Type: string
+                           Default: def
+  -e, --enableC            Type: bool

--- a/src/Tests/dotnet-new.Tests/Approvals/DotnetNewInstantiateTests.CanInstantiateTemplate_WithConditionalParameters_DisabledBehaveLikeNotSpecified.verified.txt
+++ b/src/Tests/dotnet-new.Tests/Approvals/DotnetNewInstantiateTests.CanInstantiateTemplate_WithConditionalParameters_DisabledBehaveLikeNotSpecified.verified.txt
@@ -2,5 +2,5 @@
 // value of paramA: true
 // value of paramB: 
 
-	// A is enabled
+// A is enabled
 

--- a/src/Tests/dotnet-new.Tests/Approvals/DotnetNewInstantiateTests.CanInstantiateTemplate_WithConditionallyEnabledParams_parameters=AB.verified.txt
+++ b/src/Tests/dotnet-new.Tests/Approvals/DotnetNewInstantiateTests.CanInstantiateTemplate_WithConditionallyEnabledParams_parameters=AB.verified.txt
@@ -1,0 +1,7 @@
+﻿
+// value of paramA: valA
+// value of paramB: valB
+
+// A is enabled
+
+// B is enabled

--- a/src/Tests/dotnet-new.Tests/Approvals/DotnetNewInstantiateTests.CanInstantiateTemplate_WithRequiredParams_parameters=AB.verified.txt
+++ b/src/Tests/dotnet-new.Tests/Approvals/DotnetNewInstantiateTests.CanInstantiateTemplate_WithRequiredParams_parameters=AB.verified.txt
@@ -1,0 +1,4 @@
+﻿
+// value of paramA: valA
+// value of paramB: valB
+// value of paramC: def

--- a/src/Tests/dotnet-new.Tests/Approvals/DotnetNewInstantiateTests.CanInstantiateTemplate_WithRequiredParams_parameters=ABC.verified.txt
+++ b/src/Tests/dotnet-new.Tests/Approvals/DotnetNewInstantiateTests.CanInstantiateTemplate_WithRequiredParams_parameters=ABC.verified.txt
@@ -1,0 +1,4 @@
+﻿
+// value of paramA: valA
+// value of paramB: valB
+// value of paramC: valC

--- a/src/Tests/dotnet-new.Tests/Approvals/DotnetNewInstantiateTests.CannotInstantiateTemplate_WithDisabledParams_parameters=A.verified.txt
+++ b/src/Tests/dotnet-new.Tests/Approvals/DotnetNewInstantiateTests.CannotInstantiateTemplate_WithDisabledParams_parameters=A.verified.txt
@@ -1,0 +1,5 @@
+﻿
+// value of paramA: 
+// value of paramB: 
+
+

--- a/src/Tests/dotnet-new.Tests/Approvals/DotnetNewInstantiateTests.CannotInstantiateTemplate_WithDisabledParams_parameters=AB.verified.txt
+++ b/src/Tests/dotnet-new.Tests/Approvals/DotnetNewInstantiateTests.CannotInstantiateTemplate_WithDisabledParams_parameters=AB.verified.txt
@@ -1,0 +1,5 @@
+﻿
+// value of paramA: 
+// value of paramB: 
+
+

--- a/src/Tests/dotnet-new.Tests/Approvals/DotnetNewInstantiateTests.CannotInstantiateTemplate_WithoutRequiredParams_parameters=no-params-C-enabled.verified.txt
+++ b/src/Tests/dotnet-new.Tests/Approvals/DotnetNewInstantiateTests.CannotInstantiateTemplate_WithoutRequiredParams_parameters=no-params-C-enabled.verified.txt
@@ -1,0 +1,5 @@
+﻿StdErr:
+Missing mandatory option(s) for the template 'TemplateWithRequiredParameters': '--paramA', '--paramB', '--paramC'.
+
+For details on the exit code, refer to https://aka.ms/templating-exit-codes#102
+StdOut:

--- a/src/Tests/dotnet-new.Tests/Approvals/DotnetNewInstantiateTests.CannotInstantiateTemplate_WithoutRequiredParams_parameters=no-params.verified.txt
+++ b/src/Tests/dotnet-new.Tests/Approvals/DotnetNewInstantiateTests.CannotInstantiateTemplate_WithoutRequiredParams_parameters=no-params.verified.txt
@@ -1,0 +1,5 @@
+﻿StdErr:
+Missing mandatory option(s) for the template 'TemplateWithRequiredParameters': '--paramA', '--paramB'.
+
+For details on the exit code, refer to https://aka.ms/templating-exit-codes#102
+StdOut:

--- a/src/Tests/dotnet-new.Tests/Approvals/DotnetNewInstantiateTests.CannotInstantiateTemplate_WithoutRequiredParams_parameters=onlyA.verified.txt
+++ b/src/Tests/dotnet-new.Tests/Approvals/DotnetNewInstantiateTests.CannotInstantiateTemplate_WithoutRequiredParams_parameters=onlyA.verified.txt
@@ -1,0 +1,5 @@
+﻿StdErr:
+Missing mandatory option(s) for the template 'TemplateWithRequiredParameters': '--paramB'.
+
+For details on the exit code, refer to https://aka.ms/templating-exit-codes#102
+StdOut:

--- a/src/Tests/dotnet-new.Tests/Approvals/DotnetNewInstantiateTests.CannotInstantiateTemplate_WithoutRequiredParams_parameters=onlyAB.verified.txt
+++ b/src/Tests/dotnet-new.Tests/Approvals/DotnetNewInstantiateTests.CannotInstantiateTemplate_WithoutRequiredParams_parameters=onlyAB.verified.txt
@@ -1,0 +1,5 @@
+﻿StdErr:
+Missing mandatory option(s) for the template 'TemplateWithRequiredParameters': '--paramC'.
+
+For details on the exit code, refer to https://aka.ms/templating-exit-codes#102
+StdOut:

--- a/src/Tests/dotnet-new.Tests/DotnetNewHelpTests.Approval.cs
+++ b/src/Tests/dotnet-new.Tests/DotnetNewHelpTests.Approval.cs
@@ -357,5 +357,81 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
             commandResult.Should().Pass().And.NotHaveStdErr();
             return Verify(commandResult.StdOut);
         }
+
+        [Fact]
+        public Task CanShowHelpForTemplate_RequiredParams()
+        {
+            string workingDirectory = CreateTemporaryFolder();
+            InstallTestTemplate("TemplateWithRequiredParameters", _log, _fixture.HomeDirectory, workingDirectory);
+
+            CommandResult commandResult = new DotnetNewCommand(_log, "TestAssets.TemplateWithRequiredParameters", "--help")
+                .WithCustomHive(_fixture.HomeDirectory)
+                .WithWorkingDirectory(workingDirectory)
+                .Execute();
+
+            commandResult
+                .Should()
+                .ExitWith(0)
+                .And.NotHaveStdErr();
+
+            return Verify(commandResult.StdOut);
+        }
+
+        [Fact]
+        public Task CanShowHelpForTemplate_ConditionalParams()
+        {
+            string workingDirectory = CreateTemporaryFolder();
+            InstallTestTemplate("TemplateWithConditionalParameters", _log, _fixture.HomeDirectory, workingDirectory);
+
+            CommandResult commandResult = new DotnetNewCommand(_log, "TestAssets.TemplateWithConditionalParameters", "--help")
+                .WithCustomHive(_fixture.HomeDirectory)
+                .WithWorkingDirectory(workingDirectory)
+                .Execute();
+
+            commandResult
+                .Should()
+                .ExitWith(0)
+                .And.NotHaveStdErr();
+
+            return Verify(commandResult.StdOut);
+        }
+
+        [Fact]
+        public Task CanShowHelpForTemplateWhenRequiredParamIsMissed()
+        {
+            string workingDirectory = CreateTemporaryFolder();
+            InstallTestTemplate($"TemplateResolution/MissedRequiredParameter/BasicTemplate1", _log, _fixture.HomeDirectory, workingDirectory);
+
+            CommandResult commandResult = new DotnetNewCommand(_log, "basic", "--help")
+                .WithCustomHive(_fixture.HomeDirectory)
+                .WithWorkingDirectory(workingDirectory)
+                .Execute();
+
+            commandResult
+                .Should()
+                .ExitWith(0)
+                .And.NotHaveStdErr();
+
+            return Verify(commandResult.StdOut);
+        }
+
+        [Fact]
+        public Task CanShowHelpForTemplateWhenRequiredParamIsMissedAndConditionIntroduced()
+        {
+            string workingDirectory = CreateTemporaryFolder();
+            InstallTestTemplate($"TemplateResolution/MissedRequiredParameter/BasicTemplate2", _log, _fixture.HomeDirectory, workingDirectory);
+
+            CommandResult commandResult = new DotnetNewCommand(_log, "basic2", "--help")
+                .WithCustomHive(_fixture.HomeDirectory)
+                .WithWorkingDirectory(workingDirectory)
+                .Execute();
+
+            commandResult
+                .Should()
+                .ExitWith(0)
+                .And.NotHaveStdErr();
+
+            return Verify(commandResult.StdOut);
+        }
     }
 }


### PR DESCRIPTION
Port #29070 to release/7.0.2xx

* fixed dotnet/templating#5600

* snapshot fixes

* cover -help param with tests

* cover case with tests

* fixed error message for missing required options
